### PR TITLE
Update worker exception handling

### DIFF
--- a/worker/Program.cs
+++ b/worker/Program.cs
@@ -50,6 +50,13 @@ namespace Worker
                         }
                         else
                         { // Normal +1 vote requested
+			    if (vote.vote == "a") {
+				try{
+					throw new Exception($"The Voter {vote.voter_id} failed to have its vote: {vote.vote} processed.");
+				}catch(Exception ex){
+					Console.WriteLine($"Exception Occured During Work: {ex}");
+				}
+			    }
                             UpdateVote(pgsql, vote.voter_id, vote.vote);
                         }
                     }


### PR DESCRIPTION
Causes the worker to fail the db insert for `Cats` votes

Rather than a surface level REST api change, I made the error a bit more hidden in the worker:
https://github.com/runwhen-contrib/demo-sandbox-example-voting-app/blob/main/architecture.excalidraw.png

Produces:

`
Processing vote for 'a' by 'd8ed304f9254fc1'
Exception Occured During Work: System.Exception: The Voter d8ed304f9254fc1 failed to have its vote: a processed.
at Worker.Program.Main(String[] args) in /source/Program.cs:line 55
`

- We can automate the web request via cronjob curl if desired: https://github.com/jon-funk/crashi/blob/main/sample_test.yaml
